### PR TITLE
models documentation: add note about validation dict key names

### DIFF
--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -376,6 +376,8 @@ You can also add validators by passing a dict to the `__validators__` argument.
 {!.tmp_examples/models_dynamic_validators.py!}
 ```
 
+Notice that the keys of the dict follow the pattern `{field name}_validator`.
+
 ## Custom Root Types
 
 Pydantic models can be defined with a custom root type by declaring the `__root__` field. 


### PR DESCRIPTION
> As this is a single-line documentation change, I'd suggest this is "trivial" and therefore doesn't have an associated issue. I'm happy to go back and do that if necessary.

## Change Summary

Add a note to the model documentation that explicitly calls out the pattern used by the validation dict. The keys are *not* the field names; rather, they follow the pattern `{field name}_validator`. This can save users a bit of time if they don't read the code sample very carefully (like me!).

Even better might be to warn/raise when there are keys in the dict that don't correspond to fields on the model; however, I'm not familiar with pydantic internals enough to know if this is feasible.

## Related issue number

n/a

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
